### PR TITLE
Support all types of connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,6 @@ An [Alfred 3](https://www.alfredapp.com/) workflow for opening databases in [Tab
 
 Simply type `tp` and you will be presented with a list of database connections you have added to TablePlus. You can type to filter by name, then press `Enter` to open the database within TablePlus.
 
-## Notes
-
-This workflow currently only supports MySQL, PostgreSQL, and SQLite. I don't have Microsoft SQL Server or Redis setup on my machine, so I can't test it. If you'd like to add support, feel free to submit a pull request.
-
 ## Credits
 
 Special thanks to [Phill Ayers](https://github.com/payers1) for the inspiration from his [alfred-postico-favorites-workflow](https://github.com/payers1/alfred-postico-favorites-workflow).

--- a/workflow/main.rb
+++ b/workflow/main.rb
@@ -18,6 +18,7 @@ module AlfredTablePlus
 
     def output_json
       connections.each do |connection|
+        driver = connection['Driver'].downcase
         connection_string = "tableplus://?id=" + connection['ID']
 
         workflow.result

--- a/workflow/main.rb
+++ b/workflow/main.rb
@@ -3,8 +3,6 @@ require_relative 'lib/plist/plist'
 
 module AlfredTablePlus
   class Browse
-    SUPPORTED_DBS = %w[mysql postgresql sqlite].freeze
-
     attr_reader :workflow, :connections
 
     def initialize
@@ -18,25 +16,9 @@ module AlfredTablePlus
       print workflow.output
     end
 
-    def supported_driver?(driver)
-      SUPPORTED_DBS.include?(driver)
-    end
-
-    def build_connection_string(driver, connection)
-      return connection['DatabasePath'] if driver == 'sqlite'
-
-      host = connection['DatabaseHost']
-      db_name = connection['DatabaseName']
-      user = connection['DatabaseUser']
-
-      "#{driver}://#{user}@#{host}/#{db_name}"
-    end
-
     def output_json
       connections.each do |connection|
-        driver = connection['Driver'].downcase
-        next unless supported_driver?(driver)
-        connection_string = build_connection_string(driver, connection)
+        connection_string = "tableplus://?id=" + connection['ID']
 
         workflow.result
                 .uid(connection['ID'])


### PR DESCRIPTION
This PR changes the connection string to the 'tableplus' protocol. Any connection you specify in TablePlus will just work this way. Much better 👍